### PR TITLE
Organize reply and instruction

### DIFF
--- a/lib/ink_flier/round.ex
+++ b/lib/ink_flier/round.ex
@@ -146,7 +146,7 @@ defmodule InkFlier.Round do
     if all_locked_in?(t) do
       reply
       |> add_crash_instructions
-      |> Reply.add_instruction({:end_of_round, t.round_number})
+      |> Reply.add_instruction(Instruction.end_of_round(t.round_number))
     else
       reply
     end

--- a/lib/ink_flier/round.ex
+++ b/lib/ink_flier/round.ex
@@ -61,6 +61,7 @@ defmodule InkFlier.Round do
     t
     |> Reply.add_instruction(Instruction.new_round(round_number))
     |> Reply.add_instruction(Instruction.send_summary(t.start_of_round_board, :all))
+    raise "next, continue updating all the Reply.* calls like above"
   end
 
   @doc """

--- a/lib/ink_flier/round.ex
+++ b/lib/ink_flier/round.ex
@@ -59,7 +59,7 @@ defmodule InkFlier.Round do
     t = struct!(__MODULE__, ~M{round_number, board: current_board, start_of_round_board: current_board})
 
     t
-    |> Reply.add_instruction(Instruction.new_round(round_number))
+    |> Reply.add_instruction(Instruction.new_round(round_number, :all))
     |> Reply.add_instruction(Instruction.send_summary(t.start_of_round_board, :all))
   end
 
@@ -110,8 +110,7 @@ defmodule InkFlier.Round do
   @spec summary(t, Game.member_id) :: Reply.t
   def summary(t, member) do
     t
-    raise "Here next to continue the Reply.add_instruction converts like above :)"
-    |> Reply.add_instruction(&{:notify_member, member, {:new_round, &1.round_number}})
+    |> Reply.add_instruction(Instruction.new_round(t.round_number, member))
     |> Reply.add_instruction(Instruction.send_summary(t.start_of_round_board, member))
   end
 

--- a/lib/ink_flier/round.ex
+++ b/lib/ink_flier/round.ex
@@ -116,11 +116,11 @@ defmodule InkFlier.Round do
 
 
   defp check_legal_move(t, player, destination) do
-    if Board.legal_move?(t.board, player, destination), do: :ok, else: reply_error(t, player, :illegal_destination)
+    if Board.legal_move?(t.board, player, destination), do: :ok, else: t |> Reply.add_instruction(Instruction.error(player, :illegal_destination))
   end
 
   defp check_not_already_locked_in(t, player) do
-    unless locked_in?(t, player), do: :ok, else: reply_error(t, player, :already_locked_in)
+    unless locked_in?(t, player), do: :ok, else: t |> Reply.add_instruction(Instruction.error(player, :already_locked_in))
   end
 
 
@@ -155,8 +155,6 @@ defmodule InkFlier.Round do
   defp locked_in?(t, player), do: player in t.locked_in
 
   defp all_locked_in?(t), do: MapSet.equal?(t.locked_in, players_set(t))
-
-  defp reply_error(t, player, msg), do: Reply.add_instruction(t, {:notify_player, player, {:error, msg}})
 
   defp players_set(t), do: t.board |> Board.players |> MapSet.new
 

--- a/lib/ink_flier/round.ex
+++ b/lib/ink_flier/round.ex
@@ -139,7 +139,6 @@ defmodule InkFlier.Round do
   defp handle_crashes({t, _instructions} = reply) do
     t.crashed_this_round
     |> Enum.reverse
-    raise "Here next for a bit more Reply cleaning"
     |> Enum.reduce(reply, &Reply.add_instruction(&2, {:notify_room, &1}))
   end
 

--- a/lib/ink_flier/round.ex
+++ b/lib/ink_flier/round.ex
@@ -11,6 +11,7 @@ defmodule InkFlier.Round do
   import TinyMaps
 
   alias __MODULE__.Reply
+  alias __MODULE__.Instruction
   alias InkFlier.Game
   alias InkFlier.Board
   alias InkFlier.RaceTrack.Obstacle
@@ -56,7 +57,7 @@ defmodule InkFlier.Round do
   @spec new(Board.t, round_number) :: Reply.t
   def new(current_board, round_number) do
     struct!(__MODULE__, ~M{round_number, board: current_board, start_of_round_board: current_board})
-    |> Reply.new_round(round_number)
+    |> Reply.add_instruction(Instruction.new_round(round_number))
     |> Reply.send_summary(:all)
   end
 

--- a/lib/ink_flier/round.ex
+++ b/lib/ink_flier/round.ex
@@ -143,7 +143,13 @@ defmodule InkFlier.Round do
   end
 
   defp maybe_end_round({t, _} = reply) do
-    unless all_locked_in?(t), do: reply, else: reply |> add_crash_instructions |> Reply.add_instruction({:end_of_round, t.round_number})
+    if all_locked_in?(t) do
+      reply
+      |> add_crash_instructions
+      |> Reply.add_instruction({:end_of_round, t.round_number})
+    else
+      reply
+    end
   end
 
   defp locked_in?(t, player), do: player in t.locked_in

--- a/lib/ink_flier/round.ex
+++ b/lib/ink_flier/round.ex
@@ -130,20 +130,20 @@ defmodule InkFlier.Round do
 
       {{:collision, obstacle_name_set}, new_board} ->
         put_in(t.board, new_board)
-        |> update_crashed(&[{:crash, player, destination, obstacle_name_set} | &1])
+        |> update_crashed(&[Instruction.crash(player, destination, obstacle_name_set) | &1])
     end
   end
 
   defp update_crashed(t, func), do: update_in(t.crashed_this_round, func)
 
-  defp handle_crashes({t, _instructions} = reply) do
+  defp add_crash_instructions({t, _instructions} = reply) do
     t.crashed_this_round
     |> Enum.reverse
-    |> Enum.reduce(reply, &Reply.add_instruction(&2, {:notify_room, &1}))
+    |> Enum.reduce(reply, &Reply.add_instruction(&2, &1))
   end
 
   defp maybe_end_round({t, _} = reply) do
-    unless all_locked_in?(t), do: reply, else: reply |> handle_crashes |> Reply.add_instruction({:end_of_round, t.round_number})
+    unless all_locked_in?(t), do: reply, else: reply |> add_crash_instructions |> Reply.add_instruction({:end_of_round, t.round_number})
   end
 
   defp locked_in?(t, player), do: player in t.locked_in

--- a/lib/ink_flier/round.ex
+++ b/lib/ink_flier/round.ex
@@ -56,9 +56,11 @@ defmodule InkFlier.Round do
   @doc "Build a new round and initial notification instructions"
   @spec new(Board.t, round_number) :: Reply.t
   def new(current_board, round_number) do
-    struct!(__MODULE__, ~M{round_number, board: current_board, start_of_round_board: current_board})
+    t = struct!(__MODULE__, ~M{round_number, board: current_board, start_of_round_board: current_board})
+
+    t
     |> Reply.add_instruction(Instruction.new_round(round_number))
-    |> Reply.send_summary(:all)
+    |> Reply.add_instruction(Instruction.send_summary(t.start_of_round_board, :all))
   end
 
   @doc """
@@ -109,7 +111,7 @@ defmodule InkFlier.Round do
   def summary(t, member) do
     t
     |> Reply.add_instruction(&{:notify_member, member, {:new_round, &1.round_number}})
-    |> Reply.send_summary(member)
+    |> Reply.add_instruction(Instruction.send_summary(t.start_of_round_board, member))
   end
 
 

--- a/lib/ink_flier/round.ex
+++ b/lib/ink_flier/round.ex
@@ -139,6 +139,7 @@ defmodule InkFlier.Round do
   defp handle_crashes({t, _instructions} = reply) do
     t.crashed_this_round
     |> Enum.reverse
+    raise "Here next for a bit more Reply cleaning"
     |> Enum.reduce(reply, &Reply.add_instruction(&2, {:notify_room, &1}))
   end
 

--- a/lib/ink_flier/round.ex
+++ b/lib/ink_flier/round.ex
@@ -110,6 +110,7 @@ defmodule InkFlier.Round do
   @spec summary(t, Game.member_id) :: Reply.t
   def summary(t, member) do
     t
+    raise "Here next to continue the Reply.add_instruction converts like above :)"
     |> Reply.add_instruction(&{:notify_member, member, {:new_round, &1.round_number}})
     |> Reply.add_instruction(Instruction.send_summary(t.start_of_round_board, member))
   end

--- a/lib/ink_flier/round.ex
+++ b/lib/ink_flier/round.ex
@@ -61,7 +61,6 @@ defmodule InkFlier.Round do
     t
     |> Reply.add_instruction(Instruction.new_round(round_number))
     |> Reply.add_instruction(Instruction.send_summary(t.start_of_round_board, :all))
-    raise "next, continue updating all the Reply.* calls like above"
   end
 
   @doc """
@@ -85,7 +84,7 @@ defmodule InkFlier.Round do
       t
       |> maybe_crash(player, destination)
       |> lock_in(player)
-      |> Reply.player_locked_in(player)
+      |> Reply.add_instruction(&Instruction.player_locked_in(player, speed(&1, player)))
       |> maybe_end_round
     end
   end

--- a/lib/ink_flier/round/instruction.ex
+++ b/lib/ink_flier/round/instruction.ex
@@ -26,6 +26,10 @@ defmodule InkFlier.Round.Instruction do
     {:notify_room, {:crash, player, destination, obstacle_name_set}}
   end
 
+  def error(player, msg) do
+    {:notify_player, player, {:error, msg}}
+  end
+
   def new_round(round_number, :all), do: {:notify_room, {:new_round, round_number}}
   def new_round(round_number, member), do: {:notify_member, member, {:new_round, round_number}}
 

--- a/lib/ink_flier/round/instruction.ex
+++ b/lib/ink_flier/round/instruction.ex
@@ -25,25 +25,21 @@ defmodule InkFlier.Round.Instruction do
 
   def new_round(round_number), do: {:notify_room, {:new_round, round_number}}
 
-  def send_summary(reply, :all) do
-    add_instruction_for_each_player_position(reply, &Reply.add_instruction(&2, {:notify_room, &1}))
-  end
-
-  def send_summary(reply, member) do
-    add_instruction_for_each_player_position(reply, &Reply.add_instruction(&2, {:notify_member, member, &1}))
-  end
-
-
-  defp add_instruction_for_each_player_position(reply, instruction_func) do
-    {round, _instruction} = reply
-    board = Round.start_of_round_board(round)
-
+  def send_summary(board, :all) do
     for player <- Board.players(board) do
-      {:player_position, player, %{
+      {:notify_room, {:player_position, player, %{
         coord: Board.current_position(board, player),
         speed: Board.speed(board, player),
-      }}
+      }}}
     end
-    |> Enum.reduce(reply, instruction_func)
+  end
+
+  def send_summary(board, member) do
+    for player <- Board.players(board) do
+      {:notify_member, member, {:player_position, player, %{
+        coord: Board.current_position(board, player),
+        speed: Board.speed(board, player),
+      }}}
+    end
   end
 end

--- a/lib/ink_flier/round/instruction.ex
+++ b/lib/ink_flier/round/instruction.ex
@@ -22,6 +22,10 @@ defmodule InkFlier.Round.Instruction do
     ]
   end
 
+  def crash(player, destination, obstacle_name_set) do
+    {:notify_room, {:crash, player, destination, obstacle_name_set}}
+  end
+
   def new_round(round_number, :all), do: {:notify_room, {:new_round, round_number}}
   def new_round(round_number, member), do: {:notify_member, member, {:new_round, round_number}}
 

--- a/lib/ink_flier/round/instruction.ex
+++ b/lib/ink_flier/round/instruction.ex
@@ -1,7 +1,5 @@
 defmodule InkFlier.Round.Instruction do
-  alias InkFlier.Round
   alias InkFlier.Board
-  alias InkFlier.Round.Reply
 
   @doc """
   Instructions after locking in a player
@@ -17,10 +15,11 @@ defmodule InkFlier.Round.Instruction do
       ]
 
   """
-  def player_locked_in(reply, player) do
-    reply
-    |> Reply.add_instruction({:notify_room, {:player_locked_in, player}})
-    |> Reply.add_instruction(&{:notify_player, player, {:ok, {:speed, Round.speed(&1, player)}}})
+  def player_locked_in(player, speed) do
+    [
+      {:notify_room, {:player_locked_in, player}},
+      {:notify_player, player, {:ok, {:speed, speed}}},
+    ]
   end
 
   def new_round(round_number), do: {:notify_room, {:new_round, round_number}}

--- a/lib/ink_flier/round/instruction.ex
+++ b/lib/ink_flier/round/instruction.ex
@@ -29,6 +29,8 @@ defmodule InkFlier.Round.Instruction do
   def new_round(round_number, :all), do: {:notify_room, {:new_round, round_number}}
   def new_round(round_number, member), do: {:notify_member, member, {:new_round, round_number}}
 
+  def end_of_round(round_number), do: {:end_of_round, round_number}
+
   def send_summary(board, :all) do
     for position <- positions(board), do: {:notify_room, position}
   end

--- a/lib/ink_flier/round/instruction.ex
+++ b/lib/ink_flier/round/instruction.ex
@@ -23,9 +23,7 @@ defmodule InkFlier.Round.Instruction do
     |> Reply.add_instruction(&{:notify_player, player, {:ok, {:speed, Round.speed(&1, player)}}})
   end
 
-  def new_round(reply, round_number) do
-    Reply.add_instruction(reply, {:notify_room, {:new_round, round_number}})
-  end
+  def new_round(round_number), do: {:notify_room, {:new_round, round_number}}
 
   def send_summary(reply, :all) do
     add_instruction_for_each_player_position(reply, &Reply.add_instruction(&2, {:notify_room, &1}))

--- a/lib/ink_flier/round/instruction.ex
+++ b/lib/ink_flier/round/instruction.ex
@@ -22,7 +22,8 @@ defmodule InkFlier.Round.Instruction do
     ]
   end
 
-  def new_round(round_number), do: {:notify_room, {:new_round, round_number}}
+  def new_round(round_number, :all), do: {:notify_room, {:new_round, round_number}}
+  def new_round(round_number, member), do: {:notify_member, member, {:new_round, round_number}}
 
   def send_summary(board, :all) do
     for position <- positions(board), do: {:notify_room, position}

--- a/lib/ink_flier/round/instruction.ex
+++ b/lib/ink_flier/round/instruction.ex
@@ -26,20 +26,20 @@ defmodule InkFlier.Round.Instruction do
   def new_round(round_number), do: {:notify_room, {:new_round, round_number}}
 
   def send_summary(board, :all) do
-    for player <- Board.players(board) do
-      {:notify_room, {:player_position, player, %{
-        coord: Board.current_position(board, player),
-        speed: Board.speed(board, player),
-      }}}
-    end
+    for position <- positions(board), do: {:notify_room, position}
   end
 
   def send_summary(board, member) do
+    for position <- positions(board), do: {:notify_member, member, position}
+  end
+
+
+  defp positions(board) do
     for player <- Board.players(board) do
-      {:notify_member, member, {:player_position, player, %{
+      {:player_position, player, %{
         coord: Board.current_position(board, player),
         speed: Board.speed(board, player),
-      }}}
+      }}
     end
   end
 end

--- a/lib/ink_flier/round/reply.ex
+++ b/lib/ink_flier/round/reply.ex
@@ -4,11 +4,8 @@ defmodule InkFlier.Round.Reply do
   """
 
   alias InkFlier.Round
-  alias InkFlier.Round.Instruction
 
   @type t :: {Round.t, [Round.instruction]}
-
-  defdelegate player_locked_in(t, player), to: Instruction
 
 
   @spec add_instruction(Round.t, any) :: t

--- a/lib/ink_flier/round/reply.ex
+++ b/lib/ink_flier/round/reply.ex
@@ -1,6 +1,6 @@
 defmodule InkFlier.Round.Reply do
   @moduledoc """
-  Helper module for managing a Round's reply, which consists of the Round itself, plus a list of Instructions
+  An abstraction for returning both an updated Round and a of notification Instructions
   """
 
   alias InkFlier.Round

--- a/lib/ink_flier/round/reply.ex
+++ b/lib/ink_flier/round/reply.ex
@@ -9,7 +9,6 @@ defmodule InkFlier.Round.Reply do
   @type t :: {Round.t, [Round.instruction]}
 
   defdelegate player_locked_in(t, player), to: Instruction
-  defdelegate new_round(t, round_number), to: Instruction
   defdelegate send_summary(t, target), to: Instruction
 
 

--- a/lib/ink_flier/round/reply.ex
+++ b/lib/ink_flier/round/reply.ex
@@ -30,6 +30,9 @@ defmodule InkFlier.Round.Reply do
     add_instruction(t, [new_instruction])
   end
 
+#   def round(t), do: elem(t, 0)
+#   def instructions(t), do: elem(t, 1)
+
 
   defp new(round), do: {round, []}
 

--- a/lib/ink_flier/round/reply.ex
+++ b/lib/ink_flier/round/reply.ex
@@ -9,7 +9,6 @@ defmodule InkFlier.Round.Reply do
   @type t :: {Round.t, [Round.instruction]}
 
   defdelegate player_locked_in(t, player), to: Instruction
-  defdelegate send_summary(t, target), to: Instruction
 
 
   @spec add_instruction(Round.t, any) :: t


### PR DESCRIPTION
Instead of removing the Reply abstraction, just correct the "a calls b calls c calls b" mess between Round -> Reply -> Instruction -> Reply

Instruction just builds the direct notification tuples like `{:notify_room, {:player_locked_in, player}},`

Reply is an abstraction for returning both an updated Round and a of notification Instructions

And Round checks rules and calls out to the above two modules