### PR TITLE
Lobby live updates when game players change

### DIFF
--- a/assets/js/user_socket.js
+++ b/assets/js/user_socket.js
@@ -72,6 +72,11 @@ channel.on("game_created", gameWrapper => {
   appendGame(gameWrapper)
 })
 
+channel.on("game_updated", gameWrapper => {
+  const gameRow = makeGameRow(gameWrapper, NEW_GAME)
+  document.querySelector(`[data-game-id="${gameWrapper.id}"]`).replaceWith(gameRow)
+})
+
 channel.on("game_deleted", payload => {
   let target = document.querySelector(`[data-game-id="${payload.game_id}"]`)
   target.remove()

--- a/assets/js/user_socket.js
+++ b/assets/js/user_socket.js
@@ -73,7 +73,7 @@ channel.on("game_created", gameWrapper => {
 })
 
 channel.on("game_updated", gameWrapper => {
-  const gameRow = makeGameRow(gameWrapper, NEW_GAME)
+  const gameRow = makeGameRow(gameWrapper, null)
   document.querySelector(`[data-game-id="${gameWrapper.id}"]`).replaceWith(gameRow)
 })
 

--- a/lib/ink_flier/game.ex
+++ b/lib/ink_flier/game.ex
@@ -1,11 +1,12 @@
 defmodule InkFlier.Game do
   use TypedStruct
-  import TinyMaps
 
   typedstruct do
     field :creator, player_id
     field :track_id, InkFlier.RaceTrack.id
     field :players, players, default: []
+    field :notify_module, module
+    field :name, InkFlier.Lobby.game_id, required: true
   end
 
   @type observer_id :: any
@@ -15,9 +16,10 @@ defmodule InkFlier.Game do
   @type players :: [player_id]
 
   def new(opts \\ []) do
-    creator = Keyword.get(opts, :creator)
-    track_id = Keyword.get(opts, :track_id)
-    struct!(__MODULE__, ~M{creator, track_id})
+    fields = Keyword.filter(opts, fn {k,_v} ->
+      k in [:creator, :track_id, :players, :notify_module, :name]
+    end)
+    struct!(__MODULE__, fields)
   end
 
   def add_player(t, player_id) do
@@ -42,4 +44,6 @@ defmodule InkFlier.Game do
   def creator(t), do: t.creator
   def players(t), do: t.players |> Enum.reverse
   def track_id(t), do: t.track_id
+  def notify_module(t), do: t.notify_module
+  def name(t), do: t.name
 end

--- a/lib/ink_flier/game.ex
+++ b/lib/ink_flier/game.ex
@@ -2,11 +2,10 @@ defmodule InkFlier.Game do
   use TypedStruct
 
   typedstruct do
+    field :name, InkFlier.Lobby.game_id, required: true
     field :creator, player_id
     field :track_id, InkFlier.RaceTrack.id
     field :players, players, default: []
-    field :notify_module, module
-    field :name, InkFlier.Lobby.game_id, required: true
   end
 
   @type observer_id :: any
@@ -17,7 +16,7 @@ defmodule InkFlier.Game do
 
   def new(opts \\ []) do
     fields = Keyword.filter(opts, fn {k,_v} ->
-      k in [:creator, :track_id, :players, :notify_module, :name]
+      k in [:creator, :track_id, :players, :name]
     end)
     struct!(__MODULE__, fields)
   end

--- a/lib/ink_flier/game_server.ex
+++ b/lib/ink_flier/game_server.ex
@@ -25,7 +25,12 @@ defmodule InkFlier.GameServer do
   end
 
   @impl GenServer
-  def handle_call({:join, player}, _, t), do: reply_with_ok_or_error(t, Game.add_player(t, player))
+  def handle_call({:join, player}, _, t) do
+    if Game.notify_module(t) do
+      Game.notify_module(t).broadcast({:player_joined, Game.name(t), player})
+    end
+    reply_with_ok_or_error(t, Game.add_player(t, player))
+  end
 
   @impl GenServer
   def handle_call({:remove, player}, _, t), do: reply_with_ok_or_error(t, Game.remove_player(t, player))

--- a/lib/ink_flier/game_server.ex
+++ b/lib/ink_flier/game_server.ex
@@ -5,6 +5,7 @@ defmodule InkFlier.GameServer do
 
   def start_link(opts) do
     {id, opts} = Keyword.pop!(opts, :id)
+    opts = Keyword.put(opts, :name, id)
     GenServer.start_link(__MODULE__, opts, name: via(id))
   end
 

--- a/lib/ink_flier/game_server.ex
+++ b/lib/ink_flier/game_server.ex
@@ -2,6 +2,7 @@ defmodule InkFlier.GameServer do
   use GenServer
 
   alias InkFlier.Game
+  alias InkFlier.LobbyServer
 
   def start_link(opts) do
     {id, opts} = Keyword.pop!(opts, :id)
@@ -28,9 +29,7 @@ defmodule InkFlier.GameServer do
   def handle_call({:join, player}, _, t) do
     case Game.add_player(t, player) do
       {:ok, t} ->
-        if Game.notify_module(t) do
-          Game.notify_module(t).broadcast({:player_joined, Game.name(t), player})
-        end
+        LobbyServer.broadcast({:player_joined, Game.name(t), player})
         {:reply, :ok, t}
 
       {:error, _} = error -> {:reply, error, t}

--- a/lib/ink_flier/game_server.ex
+++ b/lib/ink_flier/game_server.ex
@@ -37,7 +37,14 @@ defmodule InkFlier.GameServer do
   end
 
   @impl GenServer
-  def handle_call({:remove, player}, _, t), do: reply_with_ok_or_error(t, Game.remove_player(t, player))
+  def handle_call({:remove, player}, _, t) do
+    case Game.remove_player(t, player) do
+      {:ok, t} ->
+        LobbyServer.broadcast({:player_left, Game.name(t), player})
+        {:reply, :ok, t}
+      {:error, _} = error -> {:reply, error, t}
+    end
+  end
 
   @impl GenServer
   def handle_call(:creator, _, t), do: {:reply, Game.creator(t), t}
@@ -49,11 +56,11 @@ defmodule InkFlier.GameServer do
   def handle_call(:starting_info, _, t), do: {:reply, Game.starting_info(t), t}
 
 
-  # TODO note already exists, this is getting deleted and/or re-extract/dry'd a little later
-  defp reply_with_ok_or_error(t, reply) do
-    case reply do
-      {:ok, t} -> {:reply, :ok, t}
-      {:error, _} = error -> {:reply, error, t}
-    end
-  end
+  # # TODO note already exists, this is getting deleted and/or re-extract/dry'd a little later
+  # defp reply_with_ok_or_error(t, reply) do
+  #   case reply do
+  #     {:ok, t} -> {:reply, :ok, t}
+  #     {:error, _} = error -> {:reply, error, t}
+  #   end
+  # end
 end

--- a/lib/ink_flier/game_server.ex
+++ b/lib/ink_flier/game_server.ex
@@ -26,10 +26,15 @@ defmodule InkFlier.GameServer do
 
   @impl GenServer
   def handle_call({:join, player}, _, t) do
-    if Game.notify_module(t) do
-      Game.notify_module(t).broadcast({:player_joined, Game.name(t), player})
+    case Game.add_player(t, player) do
+      {:ok, t} ->
+        if Game.notify_module(t) do
+          Game.notify_module(t).broadcast({:player_joined, Game.name(t), player})
+        end
+        {:reply, :ok, t}
+
+      {:error, _} = error -> {:reply, error, t}
     end
-    reply_with_ok_or_error(t, Game.add_player(t, player))
   end
 
   @impl GenServer
@@ -45,6 +50,7 @@ defmodule InkFlier.GameServer do
   def handle_call(:starting_info, _, t), do: {:reply, Game.starting_info(t), t}
 
 
+  # TODO note already exists, this is getting deleted and/or re-extract/dry'd a little later
   defp reply_with_ok_or_error(t, reply) do
     case reply do
       {:ok, t} -> {:reply, :ok, t}

--- a/lib/ink_flier/lobby.ex
+++ b/lib/ink_flier/lobby.ex
@@ -12,6 +12,7 @@ defmodule InkFlier.Lobby do
 
   def new(game_supervisor), do: struct!(__MODULE__, ~M{game_supervisor})
 
+  @spec generate_id :: game_id
   def generate_id do
     :crypto.strong_rand_bytes(8)
     |> Base.url_encode64(padding: false)

--- a/lib/ink_flier/lobby_server.ex
+++ b/lib/ink_flier/lobby_server.ex
@@ -44,9 +44,7 @@ defmodule InkFlier.LobbyServer do
   def whereis(game_id), do: game_id |> GameServer.via |> GenServer.whereis
   def topic, do: @topic
 
-  def broadcast({:player_joined, _game_id, _player_id} = msg) do
-    PubSub.broadcast(InkFlier.PubSub, @topic, msg)
-  end
+  def broadcast(msg), do: PubSub.broadcast(InkFlier.PubSub, @topic, msg)
 
 
   @impl GenServer

--- a/lib/ink_flier/lobby_server.ex
+++ b/lib/ink_flier/lobby_server.ex
@@ -22,6 +22,7 @@ defmodule InkFlier.LobbyServer do
   alias InkFlier.GameServer
 
   @name __MODULE__
+  @topic "room:lobby"
 
   @doc """
   On start, LobbyServer needs to know the Name of the GameSupervisor he's using.
@@ -40,7 +41,7 @@ defmodule InkFlier.LobbyServer do
   def games_info(name \\ @name), do: GenServer.call(name, :games_info)
 
   def whereis(game_id), do: game_id |> GameServer.via |> GenServer.whereis
-
+  def topic, do: @topic
 
   @impl GenServer
   def init(game_supervisor), do: {:ok, Lobby.new(game_supervisor)}

--- a/lib/ink_flier/lobby_server.ex
+++ b/lib/ink_flier/lobby_server.ex
@@ -20,6 +20,7 @@ defmodule InkFlier.LobbyServer do
   alias InkFlier.Lobby
   alias InkFlier.GameSupervisor
   alias InkFlier.GameServer
+  alias Phoenix.PubSub
 
   @name __MODULE__
   @topic "room:lobby"
@@ -45,6 +46,11 @@ defmodule InkFlier.LobbyServer do
 
   def whereis(game_id), do: game_id |> GameServer.via |> GenServer.whereis
   def topic, do: @topic
+
+  def broadcast({:player_joined, _game_id, _player_id} = msg) do
+    PubSub.broadcast(InkFlier.PubSub, @topic, msg)
+  end
+
 
   @impl GenServer
   def init(game_supervisor), do: {:ok, Lobby.new(game_supervisor)}

--- a/lib/ink_flier/lobby_server.ex
+++ b/lib/ink_flier/lobby_server.ex
@@ -35,7 +35,10 @@ defmodule InkFlier.LobbyServer do
     GenServer.start_link(__MODULE__, game_supervisor, opts)
   end
 
-  def start_game(name \\ @name, game_opts), do: GenServer.call(name, {:start_game, game_opts})
+  def start_game(name \\ @name, game_opts) do
+    game_opts = Keyword.put(game_opts, :notify_module, __MODULE__)
+    GenServer.call(name, {:start_game, game_opts})
+  end
   def delete_game(name \\ @name, game_id), do: GenServer.call(name, {:delete_game, game_id})
   def games(name \\ @name), do: GenServer.call(name, :games)
   def games_info(name \\ @name), do: GenServer.call(name, :games_info)

--- a/lib/ink_flier/lobby_server.ex
+++ b/lib/ink_flier/lobby_server.ex
@@ -36,10 +36,7 @@ defmodule InkFlier.LobbyServer do
     GenServer.start_link(__MODULE__, game_supervisor, opts)
   end
 
-  def start_game(name \\ @name, game_opts) do
-    game_opts = Keyword.put(game_opts, :notify_module, __MODULE__)
-    GenServer.call(name, {:start_game, game_opts})
-  end
+  def start_game(name \\ @name, game_opts), do: GenServer.call(name, {:start_game, game_opts})
   def delete_game(name \\ @name, game_id), do: GenServer.call(name, {:delete_game, game_id})
   def games(name \\ @name), do: GenServer.call(name, :games)
   def games_info(name \\ @name), do: GenServer.call(name, :games_info)

--- a/lib/ink_flier_web/channels/room_channel.ex
+++ b/lib/ink_flier_web/channels/room_channel.ex
@@ -39,7 +39,7 @@ defmodule InkFlierWeb.RoomChannel do
   end
 
   @impl Phoenix.Channel
-  def handle_info({:player_joined, game_id, _player_id}, socket) do
+  def handle_info({msg, game_id, _player_id}, socket) when msg in [:player_joined, :player_left] do
     game_wrapper =
       game_id
       |> GameServer.starting_info
@@ -48,6 +48,7 @@ defmodule InkFlierWeb.RoomChannel do
     broadcast(socket, "game_updated", game_wrapper)
     {:noreply, socket}
   end
+
 
   # Add authorization logic here as required.
   defp authorized?(_payload) do

--- a/lib/ink_flier_web/channels/room_channel.ex
+++ b/lib/ink_flier_web/channels/room_channel.ex
@@ -3,8 +3,9 @@ defmodule InkFlierWeb.RoomChannel do
   import TinyMaps
 
   alias InkFlier.LobbyServer
+  alias InkFlier.GameServer
 
-  @impl true
+  @impl Phoenix.Channel
   def join("room:lobby", payload, socket) do
     if authorized?(payload) do
       games =
@@ -20,7 +21,7 @@ defmodule InkFlierWeb.RoomChannel do
     end
   end
 
-  @impl true
+  @impl Phoenix.Channel
   def handle_in("create_game", _track_id, socket) do
     user = socket.assigns.user
     {:ok, game_id} = LobbyServer.start_game(creator: user)
@@ -30,13 +31,23 @@ defmodule InkFlierWeb.RoomChannel do
     {:reply, :ok, socket}
   end
 
-  @impl true
+  @impl Phoenix.Channel
   def handle_in("delete_game", game_id, socket) do
     :ok = LobbyServer.delete_game(game_id)
     broadcast(socket, "game_deleted", ~M{game_id})
     {:reply, :ok, socket}
   end
 
+  @impl Phoenix.Channel
+  def handle_info({:player_joined, game_id, _player_id}, socket) do
+    game_wrapper =
+      game_id
+      |> GameServer.starting_info
+      |> Map.put(:id, game_id)
+
+    broadcast(socket, "game_updated", game_wrapper)
+    {:noreply, socket}
+  end
 
   # Add authorization logic here as required.
   defp authorized?(_payload) do

--- a/test/ink_flier/lobby_server_and_game_server_test.exs
+++ b/test/ink_flier/lobby_server_and_game_server_test.exs
@@ -19,4 +19,10 @@ defmodule InkFlierTest.LobbyServerAndGameServer do
     :ok = GameServer.join(game_id, "Robin")
     assert_received {:player_joined, _game_id, "Robin"}
   end
+
+  test "Lobby sends a pubsub notification when games delete player" do
+    {:ok, game_id} = LobbyServer.start_game(@lobby, players: ["Bruce", "Wayne"])
+    :ok = GameServer.remove(game_id, "Bruce")
+    assert_received {:player_left, _game_id, "Bruce"}
+  end
 end

--- a/test/ink_flier/lobby_server_and_game_server_test.exs
+++ b/test/ink_flier/lobby_server_and_game_server_test.exs
@@ -23,5 +23,8 @@ defmodule InkFlierTest.LobbyServerAndGameServer do
 
     # Process.info(self(), :messages)
     # |> dbg(charlists: :as_lists)
+
+    raise "Next, start a game with lobby, then add player with game.addPlayer(thatGame..., then use exunit assert_received"
+    # {:ok, game_id} = LobbyServer.start_game(@lobby, [])
   end
 end

--- a/test/ink_flier/lobby_server_and_game_server_test.exs
+++ b/test/ink_flier/lobby_server_and_game_server_test.exs
@@ -2,29 +2,21 @@ defmodule InkFlierTest.LobbyServerAndGameServer do
   use ExUnit.Case
 
   alias InkFlier.LobbyServer
+  alias InkFlier.GameServer
   alias Phoenix.PubSub
 
   @lobby __MODULE__.LobbyServer
-  @pub_sub __MODULE__.PubSub
 
   setup do
     start_supervised!({LobbyServer, name: @lobby})
 
-    start_supervised!({Phoenix.PubSub, name: @pub_sub})
-    PubSub.subscribe(@pub_sub, LobbyServer.topic)
+    PubSub.subscribe(InkFlier.PubSub, LobbyServer.topic)
     :ok
   end
 
   test "Lobby sends a pubsub notification when games add player" do
-    # Process.info(self(), :messages)
-    # |> dbg(charlists: :as_lists)
-
-    # PubSub.broadcast(@pub_sub, LobbyServer.topic, {:user_update, %{id: 123, name: "Shane"}})
-
-    # Process.info(self(), :messages)
-    # |> dbg(charlists: :as_lists)
-
-    raise "Next, start a game with lobby, then add player with game.addPlayer(thatGame..., then use exunit assert_received"
-    # {:ok, game_id} = LobbyServer.start_game(@lobby, [])
+    {:ok, game_id} = LobbyServer.start_game(@lobby, [])
+    :ok = GameServer.join(game_id, "Robin")
+    assert_received {:player_joined, _game_id, "Robin"}
   end
 end

--- a/test/ink_flier/lobby_server_and_game_server_test.exs
+++ b/test/ink_flier/lobby_server_and_game_server_test.exs
@@ -1,0 +1,27 @@
+defmodule InkFlierTest.LobbyServerAndGameServer do
+  use ExUnit.Case
+
+  alias InkFlier.LobbyServer
+  alias Phoenix.PubSub
+
+  @lobby __MODULE__.LobbyServer
+  @pub_sub __MODULE__.PubSub
+
+  setup do
+    start_supervised!({LobbyServer, name: @lobby})
+
+    start_supervised!({Phoenix.PubSub, name: @pub_sub})
+    PubSub.subscribe(@pub_sub, LobbyServer.topic)
+    :ok
+  end
+
+  test "Lobby sends a pubsub notification when games add player" do
+    # Process.info(self(), :messages)
+    # |> dbg(charlists: :as_lists)
+
+    # PubSub.broadcast(@pub_sub, LobbyServer.topic, {:user_update, %{id: 123, name: "Shane"}})
+
+    # Process.info(self(), :messages)
+    # |> dbg(charlists: :as_lists)
+  end
+end

--- a/test/ink_flier/lobby_server_test.exs
+++ b/test/ink_flier/lobby_server_test.exs
@@ -5,8 +5,8 @@ defmodule InkFlierTest.LobbyServer do
   alias InkFlier.GameSupervisor
   alias InkFlier.GameServer
 
-  @lobby TestLobbyServer
-  @game_starter TestGameSupervisor
+  @lobby __MODULE__.LobbyServer
+  @game_starter __MODULE__.GameSupervisor
 
   setup do
     start_supervised!({GameSupervisor, name: @game_starter})

--- a/test/ink_flier/lobby_server_test.exs
+++ b/test/ink_flier/lobby_server_test.exs
@@ -2,17 +2,15 @@ defmodule InkFlierTest.LobbyServer do
   use ExUnit.Case
 
   alias InkFlier.LobbyServer
+  alias InkFlier.GameSupervisor
   alias InkFlier.GameServer
 
   @lobby __MODULE__.LobbyServer
+  @game_starter __MODULE__.GameSupervisor
 
   setup do
-    # NOTE Aparently I don't need unique GameSupervisor for tests to not collide? I can just use
-    # the Application-started one
-
-    # start_supervised!({GameSupervisor, name: @game_starter})
-    # start_supervised!({LobbyServer, name: @lobby, game_supervisor: @game_starter})
-    start_supervised!({LobbyServer, name: @lobby})
+    start_supervised!({GameSupervisor, name: @game_starter})
+    start_supervised!({LobbyServer, name: @lobby, game_supervisor: @game_starter})
     :ok
   end
 

--- a/test/ink_flier/lobby_server_test.exs
+++ b/test/ink_flier/lobby_server_test.exs
@@ -2,15 +2,17 @@ defmodule InkFlierTest.LobbyServer do
   use ExUnit.Case
 
   alias InkFlier.LobbyServer
-  alias InkFlier.GameSupervisor
   alias InkFlier.GameServer
 
   @lobby __MODULE__.LobbyServer
-  @game_starter __MODULE__.GameSupervisor
 
   setup do
-    start_supervised!({GameSupervisor, name: @game_starter})
-    start_supervised!({LobbyServer, name: @lobby, game_supervisor: @game_starter})
+    # NOTE Aparently I don't need unique GameSupervisor for tests to not collide? I can just use
+    # the Application-started one
+
+    # start_supervised!({GameSupervisor, name: @game_starter})
+    # start_supervised!({LobbyServer, name: @lobby, game_supervisor: @game_starter})
+    start_supervised!({LobbyServer, name: @lobby})
     :ok
   end
 


### PR DESCRIPTION
This works! Just like local page Lobby can see a new game (the js for EVERYONE looking at that page live-updates their screen)

And local game page viewers can see IT'S live events like "player joined game"

But now, we can see ACCROSS pages. player join  on game page sends a live update to lobby, a completely different page :)

Note 2 medium-sized changes are planned for how this is currently implemented:
1. Broadcasts will be handled on the higher channel level instead of in the engine
2. LobbyServer/Lobby will no longer be a process. It will be a normal functional module, serving as a context