### PR TITLE
Better supervisors

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,8 @@ import Config
 
 config :ink_flier,
   ecto_repos: [InkFlier.Repo],
-  generators: [timestamp_type: :utc_datetime]
+  generators: [timestamp_type: :utc_datetime],
+  supervise_games: true
 
 # Configures the endpoint
 config :ink_flier, InkFlierWeb.Endpoint,

--- a/config/test.exs
+++ b/config/test.exs
@@ -35,3 +35,6 @@ config :phoenix, :plug_init_mode, :runtime
 # Enable helpful, but potentially expensive runtime checks
 config :phoenix_live_view,
   enable_expensive_runtime_checks: true
+
+
+config :ink_flier, supervise_games: false

--- a/lib/ink_flier/application.ex
+++ b/lib/ink_flier/application.ex
@@ -7,32 +7,47 @@ defmodule InkFlier.Application do
 
   @impl true
   def start(_type, _args) do
-    children = [
+    children =
+      main_children()
+      ++ game_children()
+      ++ end_children()
+
+    opts = [strategy: :one_for_one, name: InkFlier.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+
+  # Tell Phoenix to update the endpoint configuration whenever the application is updated.
+  @impl true
+  def config_change(changed, _new, removed) do
+    InkFlierWeb.Endpoint.config_change(changed, removed)
+    :ok
+  end
+
+  def main_children do
+    [
       InkFlierWeb.Telemetry,
       InkFlier.Repo,
       {DNSCluster, query: Application.get_env(:ink_flier, :dns_cluster_query) || :ignore},
       {Phoenix.PubSub, name: InkFlier.PubSub},
       # Start the Finch HTTP client for sending emails
       {Finch, name: InkFlier.Finch},
-      # Start a worker by calling: InkFlier.Worker.start_link(arg)
-      # {InkFlier.Worker, arg},
-      # Start to serve requests, typically the last entry
       {Registry, keys: :unique, name: Registry.Game},
-      InkFlier.GameSystem,
-      InkFlierWeb.Endpoint
     ]
-
-    # See https://hexdocs.pm/elixir/Supervisor.html
-    # for other strategies and supported options
-    opts = [strategy: :one_for_one, name: InkFlier.Supervisor]
-    Supervisor.start_link(children, opts)
   end
 
-  # Tell Phoenix to update the endpoint configuration
-  # whenever the application is updated.
-  @impl true
-  def config_change(changed, _new, removed) do
-    InkFlierWeb.Endpoint.config_change(changed, removed)
-    :ok
+  def game_children do
+    if Application.get_env(:ink_flier, :supervise_games, true) do
+      [
+        InkFlier.GameSystem,
+      ]
+    else
+      []
+    end
+  end
+
+  def end_children do
+    [
+      InkFlierWeb.Endpoint
+    ]
   end
 end

--- a/lib/ink_flier/application.ex
+++ b/lib/ink_flier/application.ex
@@ -18,8 +18,7 @@ defmodule InkFlier.Application do
       # {InkFlier.Worker, arg},
       # Start to serve requests, typically the last entry
       {Registry, keys: :unique, name: Registry.Game},
-      InkFlier.GameSupervisor,
-      InkFlier.LobbyServer,
+      InkFlier.GameSystem,
       InkFlierWeb.Endpoint
     ]
 

--- a/lib/ink_flier/application.ex
+++ b/lib/ink_flier/application.ex
@@ -9,7 +9,7 @@ defmodule InkFlier.Application do
   def start(_type, _args) do
     children =
       main_children()
-      ++ game_children()
+      ++ game_children(Application.get_env(:ink_flier, :supervise_games))
       ++ end_children()
 
     opts = [strategy: :one_for_one, name: InkFlier.Supervisor]
@@ -35,15 +35,12 @@ defmodule InkFlier.Application do
     ]
   end
 
-  def game_children do
-    if Application.get_env(:ink_flier, :supervise_games, true) do
-      [
-        InkFlier.GameSystem,
-      ]
-    else
-      []
-    end
+  def game_children(true) do
+    [
+      InkFlier.GameSystem,
+    ]
   end
+  def game_children(_), do: []
 
   def end_children do
     [

--- a/lib/ink_flier/application.ex
+++ b/lib/ink_flier/application.ex
@@ -35,6 +35,9 @@ defmodule InkFlier.Application do
     ]
   end
 
+  # Situationally skip auto-starting the game supervisors when we prefer to manually start
+  # them ourselves. For example, in the tests we'll manually start_supervised!/1 these children, so
+  # state is cleared between each test
   def game_children(true), do: [InkFlier.GameSystem]
   def game_children(_), do: []
 

--- a/lib/ink_flier/application.ex
+++ b/lib/ink_flier/application.ex
@@ -35,16 +35,8 @@ defmodule InkFlier.Application do
     ]
   end
 
-  def game_children(true) do
-    [
-      InkFlier.GameSystem,
-    ]
-  end
+  def game_children(true), do: [InkFlier.GameSystem]
   def game_children(_), do: []
 
-  def end_children do
-    [
-      InkFlierWeb.Endpoint
-    ]
-  end
+  def end_children, do: [InkFlierWeb.Endpoint]
 end

--- a/lib/ink_flier/game_supervisor.ex
+++ b/lib/ink_flier/game_supervisor.ex
@@ -1,27 +1,20 @@
 defmodule InkFlier.GameSupervisor do
   use DynamicSupervisor
-
   alias InkFlier.GameServer
-
-  @typedoc "Unique global name the single GameSupervisor"
-  @type name :: module
 
   @name __MODULE__
 
   def start_link(opts) do
-    opts = Keyword.put_new(opts, :name, @name)
-    DynamicSupervisor.start_link(__MODULE__, :ok, opts)
+    DynamicSupervisor.start_link(__MODULE__, :ok, Keyword.put(opts, :name, @name))
   end
 
-  def start_game(name \\ @name, game_opts), do: DynamicSupervisor.start_child(name, {GameServer, game_opts})
-  def start_game!(name \\ @name, game_opts), do: {:ok, _pid} = start_game(name, game_opts)
+  def start_game(game_opts), do: DynamicSupervisor.start_child(@name, {GameServer, game_opts})
+  def start_game!(game_opts), do: {:ok, _pid} = start_game(game_opts)
 
-  def delete_game(name \\ @name, pid), do: DynamicSupervisor.terminate_child(name, pid)
-  def delete_game!(name \\ @name, pid), do: :ok = delete_game(name, pid)
+  def delete_game(pid), do: DynamicSupervisor.terminate_child(@name, pid)
+  def delete_game!(pid), do: :ok = delete_game(pid)
 
-  def count_children, do: DynamicSupervisor.count_children(__MODULE__)
-
-  def default_name, do: @name
+  def count_children, do: DynamicSupervisor.count_children(@name)
 
 
   @impl DynamicSupervisor

--- a/lib/ink_flier/game_supervisor.ex
+++ b/lib/ink_flier/game_supervisor.ex
@@ -4,9 +4,7 @@ defmodule InkFlier.GameSupervisor do
 
   @name __MODULE__
 
-  def start_link(opts) do
-    DynamicSupervisor.start_link(__MODULE__, :ok, Keyword.put(opts, :name, @name))
-  end
+  def start_link(opts), do: DynamicSupervisor.start_link(__MODULE__, :ok, Keyword.put(opts, :name, @name))
 
   def start_game(game_opts), do: DynamicSupervisor.start_child(@name, {GameServer, game_opts})
   def start_game!(game_opts), do: {:ok, _pid} = start_game(game_opts)

--- a/lib/ink_flier/game_supervisor.ex
+++ b/lib/ink_flier/game_supervisor.ex
@@ -19,6 +19,8 @@ defmodule InkFlier.GameSupervisor do
   def delete_game(name \\ @name, pid), do: DynamicSupervisor.terminate_child(name, pid)
   def delete_game!(name \\ @name, pid), do: :ok = delete_game(name, pid)
 
+  def count_children, do: DynamicSupervisor.count_children(__MODULE__)
+
   def default_name, do: @name
 
 

--- a/lib/ink_flier/game_system.ex
+++ b/lib/ink_flier/game_system.ex
@@ -1,0 +1,18 @@
+defmodule InkFlier.GameSystem do
+  use Supervisor
+
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, :ok, Keyword.put(opts, :name, __MODULE__))
+  end
+
+
+  @impl Supervisor
+  def init(:ok) do
+    children = [
+      InkFlier.GameSupervisor,
+      InkFlier.LobbyServer,
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/lib/ink_flier/lobby.ex
+++ b/lib/ink_flier/lobby.ex
@@ -1,16 +1,14 @@
 defmodule InkFlier.Lobby do
   use TypedStruct
-  import TinyMaps
 
   typedstruct enforce: true do
-    field :game_supervisor, InkFlier.GameSupervisor.name
     field :games, games, default: []
   end
 
   @type game_id :: any
   @type games :: [game_id]
 
-  def new(game_supervisor), do: struct!(__MODULE__, ~M{game_supervisor})
+  def new, do: struct!(__MODULE__)
 
   @spec generate_id :: game_id
   def generate_id do
@@ -19,7 +17,6 @@ defmodule InkFlier.Lobby do
   end
 
   def games(t), do: t.games |> Enum.reverse
-  def game_supervisor(t), do: t.game_supervisor
 
   def track_game_id(t, id), do: update_in(t.games, &[id | &1])
   def untrack_game_id(t, id), do: update_in(t.games, &List.delete(&1, id))

--- a/lib/ink_flier/lobby_server.ex
+++ b/lib/ink_flier/lobby_server.ex
@@ -18,20 +18,14 @@ defmodule InkFlier.LobbyServer do
 
   @name __MODULE__
 
-  def start_link(opts) do
-    opts = Keyword.put_new(opts, :name, @name)
+  def start_link(opts), do: GenServer.start_link(__MODULE__, :ok, Keyword.put(opts, :name, @name))
 
-    GenServer.start_link(__MODULE__, :ok, opts)
-  end
-
-  def start_game(name \\ @name, game_opts), do: GenServer.call(name, {:start_game, game_opts})
-  def delete_game(name \\ @name, game_id), do: GenServer.call(name, {:delete_game, game_id})
-  def games(name \\ @name), do: GenServer.call(name, :games)
-  def games_info(name \\ @name), do: GenServer.call(name, :games_info)
+  def start_game(game_opts), do: GenServer.call(@name, {:start_game, game_opts})
+  def delete_game(game_id), do: GenServer.call(@name, {:delete_game, game_id})
+  def games, do: GenServer.call(@name, :games)
+  def games_info, do: GenServer.call(@name, :games_info)
 
   def whereis(game_id), do: game_id |> GameServer.via |> GenServer.whereis
-
-  def default_name, do: @name
 
 
   @impl GenServer

--- a/lib/ink_flier_web/channels/lobby_channel.ex
+++ b/lib/ink_flier_web/channels/lobby_channel.ex
@@ -13,10 +13,8 @@ defmodule InkFlierWeb.LobbyChannel do
 
   @impl Phoenix.Channel
   def join(@main_topic, payload, socket) do
-    socket = assign_new(socket, :lobby, LobbyServer.default_name)
-
     if authorized?(payload) do
-      {:ok, LobbyServer.games_info(socket.assigns.lobby) |> Enum.reverse, socket}
+      {:ok, LobbyServer.games_info |> Enum.reverse, socket}
     else
       {:error, %{reason: "unauthorized"}}
     end
@@ -24,7 +22,7 @@ defmodule InkFlierWeb.LobbyChannel do
 
   @impl Phoenix.Channel
   def handle_in("create_game", _track_id, socket) do
-    {:ok, game_id} = LobbyServer.start_game(socket.assigns.lobby, creator: socket.assigns.user)
+    {:ok, game_id} = LobbyServer.start_game(creator: socket.assigns.user)
 
     broadcast(socket, "game_created", GameServer.summary_info(game_id))
     {:reply, :ok, socket}
@@ -32,7 +30,7 @@ defmodule InkFlierWeb.LobbyChannel do
 
   @impl Phoenix.Channel
   def handle_in("delete_game", game_id, socket) do
-    :ok = LobbyServer.delete_game(socket.assigns.lobby, game_id)
+    :ok = LobbyServer.delete_game(game_id)
 
     broadcast(socket, "game_deleted", ~M{game_id})
     {:reply, :ok, socket}

--- a/test/ink_flier/game_supervisor_test.exs
+++ b/test/ink_flier/game_supervisor_test.exs
@@ -3,23 +3,21 @@ defmodule InkFlierTest.GameSupervisor do
 
   alias InkFlier.GameSupervisor
 
-  @name TestGameSupervisor
-
   setup do
-    start_supervised!({GameSupervisor, name: @name})
+    start_supervised!(GameSupervisor)
     :ok
   end
 
 
   test "Start supervised games" do
-    {:ok, _pid} = GameSupervisor.start_game(@name, id: 3211, creator: "Bob")
-    assert DynamicSupervisor.count_children(@name).active == 1
+    {:ok, _pid} = GameSupervisor.start_game(id: 3211, creator: "Bob")
+    assert GameSupervisor.count_children.active == 1
   end
 
   test "Delete supervised games" do
-    {:ok, game_pid} = GameSupervisor.start_game(@name, id: 321)
+    {:ok, game_pid} = GameSupervisor.start_game(id: 321)
 
-    GameSupervisor.delete_game!(@name, game_pid)
-    assert DynamicSupervisor.count_children(@name).active == 0
+    GameSupervisor.delete_game!(game_pid)
+    assert GameSupervisor.count_children.active == 0
   end
 end

--- a/test/ink_flier/lobby_server_application_started_test.exs
+++ b/test/ink_flier/lobby_server_application_started_test.exs
@@ -1,15 +1,15 @@
 defmodule InkFlierTest.LobbyServerApplicationStarted do
   use ExUnit.Case
 
-  alias InkFlier.LobbyServer
-  alias InkFlier.GameServer
+  # alias InkFlier.LobbyServer
+  # alias InkFlier.GameServer
 
 
-  test "Application correctly starts LobbyServer (and his required GameSupervisor)" do
-    Application.put_env(:ink_flier, :supervise_games, true)
+  # test "Application correctly starts LobbyServer (and his required GameSupervisor)" do
+  #   Application.put_env(:ink_flier, :supervise_games, true)
 
-    assert LobbyServer.games == []
-    {:ok, game_id} = LobbyServer.start_game(creator: "Robin")
-    assert GameServer.creator(game_id) == "Robin"
-  end
+  #   assert LobbyServer.games == []
+  #   {:ok, game_id} = LobbyServer.start_game(creator: "Robin")
+  #   assert GameServer.creator(game_id) == "Robin"
+  # end
 end

--- a/test/ink_flier/lobby_server_application_started_test.exs
+++ b/test/ink_flier/lobby_server_application_started_test.exs
@@ -1,17 +1,13 @@
 defmodule InkFlierTest.LobbyServerApplicationStarted do
-  @moduledoc """
-  Multiple tests here would "bleed together" as the application-started LobbyServer (and GameSupervisor)
-  don't reset between tests
-
-  Use `lobby_server_test.exs` to test ones that DO restart those processes between each test
-  """
   use ExUnit.Case
 
   alias InkFlier.LobbyServer
   alias InkFlier.GameServer
 
 
-  test "Only test- Application correctly starts LobbyServer (and his required GameSupervisor)" do
+  test "Application correctly starts LobbyServer (and his required GameSupervisor)" do
+    Application.put_env(:ink_flier, :supervise_games, true)
+
     assert LobbyServer.games == []
     {:ok, game_id} = LobbyServer.start_game(creator: "Robin")
     assert GameServer.creator(game_id) == "Robin"

--- a/test/ink_flier/lobby_server_test.exs
+++ b/test/ink_flier/lobby_server_test.exs
@@ -4,41 +4,38 @@ defmodule InkFlierTest.LobbyServer do
   alias InkFlier.LobbyServer
   alias InkFlier.GameServer
 
-  @lobby __MODULE__.LobbyServer
-
   setup do
-    start_supervised!(InkFlier.GameSupervisor)
-    start_supervised!({LobbyServer, name: @lobby})
+    start_supervised!(InkFlier.GameSystem)
     :ok
   end
 
 
   test "games" do
-    {:ok, game_id1} = LobbyServer.start_game(@lobby, [])
-    {:ok, game_id2} = LobbyServer.start_game(@lobby, creator: "Bob")
-    assert LobbyServer.games(@lobby) == [game_id1, game_id2]
+    {:ok, game_id1} = LobbyServer.start_game([])
+    {:ok, game_id2} = LobbyServer.start_game(creator: "Bob")
+    assert LobbyServer.games == [game_id1, game_id2]
   end
 
   test "Can retrieve data from games by using their game_id" do
-    {:ok, game_id} = LobbyServer.start_game(@lobby, creator: "Bob")
+    {:ok, game_id} = LobbyServer.start_game(creator: "Bob")
     assert GameServer.creator(game_id) == "Bob"
   end
 
   test "games_info" do
-    {:ok, game_id1} = LobbyServer.start_game(@lobby, [])
-    {:ok, game_id2} = LobbyServer.start_game(@lobby, creator: "Bob")
+    {:ok, game_id1} = LobbyServer.start_game([])
+    {:ok, game_id2} = LobbyServer.start_game(creator: "Bob")
 
-    assert [info1, info2] = LobbyServer.games_info(@lobby)
+    assert [info1, info2] = LobbyServer.games_info
     assert %{name: ^game_id1, creator: nil} = info1
     assert %{name: ^game_id2, creator: "Bob"} = info2
   end
 
   test "delete_game" do
-    {:ok, game_id1} = LobbyServer.start_game(@lobby, [])
-    {:ok, game_id2} = LobbyServer.start_game(@lobby, creator: "Bob")
+    {:ok, game_id1} = LobbyServer.start_game([])
+    {:ok, game_id2} = LobbyServer.start_game(creator: "Bob")
 
-    :ok = LobbyServer.delete_game(@lobby, game_id1)
-    assert LobbyServer.games(@lobby) == [game_id2]
+    :ok = LobbyServer.delete_game(game_id1)
+    assert LobbyServer.games == [game_id2]
 
     assert LobbyServer.whereis(game_id2)
     refute LobbyServer.whereis(game_id1)

--- a/test/ink_flier/lobby_server_test.exs
+++ b/test/ink_flier/lobby_server_test.exs
@@ -2,15 +2,13 @@ defmodule InkFlierTest.LobbyServer do
   use ExUnit.Case
 
   alias InkFlier.LobbyServer
-  alias InkFlier.GameSupervisor
   alias InkFlier.GameServer
 
   @lobby __MODULE__.LobbyServer
-  @game_starter __MODULE__.GameSupervisor
 
   setup do
-    start_supervised!({GameSupervisor, name: @game_starter})
-    start_supervised!({LobbyServer, name: @lobby, game_supervisor: @game_starter})
+    start_supervised!(InkFlier.GameSupervisor)
+    start_supervised!({LobbyServer, name: @lobby})
     :ok
   end
 

--- a/test/ink_flier_web/channels/game_channel_test.exs
+++ b/test/ink_flier_web/channels/game_channel_test.exs
@@ -2,14 +2,11 @@ defmodule InkFlierWeb.GameChannelTest do
   use InkFlierWeb.ChannelCase
   import TinyMaps
   alias InkFlier.LobbyServer
-  alias InkFlier.GameSupervisor
 
-  @lobby __MODULE__.LobbyServer
   @lobby_topic "lobby:main"
 
   setup do
-    start_supervised!(GameSupervisor)
-    start_supervised!({LobbyServer, name: @lobby})
+    start_supervised!(InkFlier.GameSystem)
     :ok
   end
 
@@ -26,11 +23,11 @@ defmodule InkFlierWeb.GameChannelTest do
 
   # test "game doesn't exist, redirect gracefully" do
 
-  defp test_socket, do: socket(InkFlierWeb.UserSocket, "user_id", %{user: "Robin", lobby: @lobby})
+  defp test_socket, do: socket(InkFlierWeb.UserSocket, "user_id", %{user: "Robin"})
   defp subscribe_test_to_channel(channel, topic), do: subscribe_and_join(test_socket(), channel, topic)
 
   defp start_game(_) do
-    {:ok, game_id} = LobbyServer.start_game(@lobby, creator: "BillyBob")
+    {:ok, game_id} = LobbyServer.start_game(creator: "BillyBob")
     game_topic = "game:" <> game_id
     ~M{game_id, game_topic}
   end

--- a/test/ink_flier_web/channels/game_channel_test.exs
+++ b/test/ink_flier_web/channels/game_channel_test.exs
@@ -5,12 +5,11 @@ defmodule InkFlierWeb.GameChannelTest do
   alias InkFlier.GameSupervisor
 
   @lobby __MODULE__.LobbyServer
-  @game_starter __MODULE__.GameSupervisor
   @lobby_topic "lobby:main"
 
   setup do
-    start_supervised!({GameSupervisor, name: @game_starter})
-    start_supervised!({LobbyServer, name: @lobby, game_supervisor: @game_starter})
+    start_supervised!(GameSupervisor)
+    start_supervised!({LobbyServer, name: @lobby})
     :ok
   end
 

--- a/test/ink_flier_web/channels/lobby_channel_test.exs
+++ b/test/ink_flier_web/channels/lobby_channel_test.exs
@@ -2,13 +2,9 @@ defmodule InkFlierWeb.LobbyChannelTest do
   use InkFlierWeb.ChannelCase
   import TinyMaps
   alias InkFlier.LobbyServer
-  alias InkFlier.GameSupervisor
-
-  @lobby __MODULE__.LobbyServer
 
   setup do
-    start_supervised!(GameSupervisor)
-    start_supervised!({LobbyServer, name: @lobby})
+    start_supervised!(InkFlier.GameSystem)
     :ok
   end
 
@@ -24,7 +20,7 @@ defmodule InkFlierWeb.LobbyChannelTest do
     test "Push delete also works", ~M{socket, game_id} do
       push(socket, "delete_game", game_id) |> assert_reply(:ok)
 
-      assert LobbyServer.games_info(@lobby) |> length == 0
+      assert LobbyServer.games_info |> length == 0
       assert_broadcast "game_deleted", %{game_id: ^game_id}
     end
   end
@@ -33,7 +29,7 @@ defmodule InkFlierWeb.LobbyChannelTest do
     setup [:join_lobby, :push_create_game]
 
     test "actually creats a game" do
-      assert LobbyServer.games_info(@lobby) |> length == 1
+      assert LobbyServer.games_info |> length == 1
     end
 
     test "broadcasts the resulting game" do
@@ -44,14 +40,14 @@ defmodule InkFlierWeb.LobbyChannelTest do
 
 
   defp start_game(_) do
-    {:ok, game_id} = LobbyServer.start_game(@lobby, creator: "BillyBob")
+    {:ok, game_id} = LobbyServer.start_game(creator: "BillyBob")
     ~M{game_id}
   end
 
   defp join_lobby(_) do
     {:ok, join_reply, socket} =
       InkFlierWeb.UserSocket
-      |> socket("user_id", %{user: "Robin", lobby: @lobby})
+      |> socket("user_id", %{user: "Robin"})
       |> subscribe_and_join(InkFlierWeb.LobbyChannel, "lobby:main")
     ~M{join_reply, socket}
   end

--- a/test/ink_flier_web/channels/lobby_channel_test.exs
+++ b/test/ink_flier_web/channels/lobby_channel_test.exs
@@ -5,11 +5,10 @@ defmodule InkFlierWeb.LobbyChannelTest do
   alias InkFlier.GameSupervisor
 
   @lobby __MODULE__.LobbyServer
-  @game_starter __MODULE__.GameSupervisor
 
   setup do
-    start_supervised!({GameSupervisor, name: @game_starter})
-    start_supervised!({LobbyServer, name: @lobby, game_supervisor: @game_starter})
+    start_supervised!(GameSupervisor)
+    start_supervised!({LobbyServer, name: @lobby})
     :ok
   end
 


### PR DESCRIPTION
Before, clients (which so far was our Channel code and all of our tests) had to do a lot of "which GameSupervisor am I using?". Same with LobbyServer

Basically they had to do a ton of `GameSupervisor.do_something(SomeName, other_params)`, where `SomeName` was things like "GameSupervisorTestName" or "DefaultGameSupervisorName"

That is completely gone now. There should only ever need to be a single global GameSupervisor or LobbyServer or similar processes
- They SHOULD be started by default in Application so that running `phx.server` can use them
- But they SHOULDN'T be started by default during tests, because the tests need to MANUALLY start&stop those processes between each test
  - (So the state doesn't bleed between tests)

All if this is now the case

Which means the api no longer needs that extra 1st name param scattered all over the place

I'm pretty proud of this one <3