### PR TITLE
Bugfix remove other player x removes yourself

### DIFF
--- a/lib/ink_flier_web/channels/game_channel.ex
+++ b/lib/ink_flier_web/channels/game_channel.ex
@@ -30,16 +30,23 @@ defmodule InkFlierWeb.GameChannel do
   end
 
   @impl Phoenix.Channel
+  def handle_in("leave", ~m{target}, socket) do
+    broadcast_on_success(socket, &GameServer.remove/2, target)
+    {:reply, :ok, socket}
+  end
+
+  @impl Phoenix.Channel
   def handle_in("leave", _params, socket) do
     broadcast_on_success(socket, &GameServer.remove/2)
     {:reply, :ok, socket}
   end
 
 
-  defp broadcast_on_success(socket, game_command) do
-    ~M{user, game_id} = socket.assigns
+  defp broadcast_on_success(socket, game_command, target \\ nil) do
+    ~M{game_id} = socket.assigns
+    target = target || socket.assigns.user
 
-    case game_command.(game_id, user) do
+    case game_command.(game_id, target) do
       :ok ->
         players = GameServer.players(game_id)
 

--- a/lib/ink_flier_web/channels/game_channel.ex
+++ b/lib/ink_flier_web/channels/game_channel.ex
@@ -39,22 +39,17 @@ defmodule InkFlierWeb.GameChannel do
   end
 
 
-  defp ok(socket), do: {:reply, :ok, socket}
-
-  defp update_game_and_broadcast_on_success(socket, func, target) do
-    func.(socket.assigns.game_id, target)
-    |> broadcast_on_success(socket)
-    |> ok
-  end
-
-  defp broadcast_on_success(:ok, socket) do
+  defp update_game_and_broadcast_on_success(socket, add_or_remove_player, target) do
     ~M{game_id} = socket.assigns
-    players = GameServer.players(game_id)
-    broadcast(socket, "players_updated", ~M{players})
-    LobbyChannel.notify_game_updated(game_id)
-    socket
+    case add_or_remove_player.(game_id, target) do
+      :ok ->
+        broadcast(socket, "players_updated", %{players: GameServer.players(game_id)})
+        LobbyChannel.notify_game_updated(game_id)
+
+      _no_state_change -> nil
+    end
+    {:reply, :ok, socket}
   end
-  defp broadcast_on_success(_, _), do: nil
 
   defp authorized?(_payload), do: true
 end

--- a/lib/ink_flier_web/channels/game_channel.ex
+++ b/lib/ink_flier_web/channels/game_channel.ex
@@ -36,24 +36,20 @@ defmodule InkFlierWeb.GameChannel do
     target = target || socket.assigns.user
     game_id = socket.assigns.game_id
 
-    add_or_remove_player
-    |> wrap(game_id, target)
-    |> broadcast_on_success(socket)
+    game_id
+    |> add_or_remove_player.(target)
+    |> broadcast_on_success(game_id, socket)
     |> ok
   end
 
-  defp wrap(add_or_remove_player, game_id, target) do
-    reply = add_or_remove_player.(game_id, target)
-    {reply, game_id}
-  end
 
-  defp broadcast_on_success({:ok, game_id}, socket) do
+  defp broadcast_on_success(:ok, game_id, socket) do
     :ok = broadcast(socket, "players_updated", %{players: GameServer.players(game_id)})
     :ok = LobbyChannel.notify_game_updated(game_id)
 
     socket
   end
-  defp broadcast_on_success(_, socket), do: socket
+  defp broadcast_on_success(_, _, socket), do: socket
 
 
   defp ok(socket), do: {:reply, :ok, socket}

--- a/lib/ink_flier_web/channels/game_channel.ex
+++ b/lib/ink_flier_web/channels/game_channel.ex
@@ -36,20 +36,24 @@ defmodule InkFlierWeb.GameChannel do
     target = target || socket.assigns.user
     game_id = socket.assigns.game_id
 
-    game_id
-    |> add_or_remove_player.(target)
-    |> broadcast_on_success(game_id, socket)
+    add_or_remove_player
+    |> wrap(game_id, target)
+    |> broadcast_on_success(socket)
     |> ok
   end
 
+  defp wrap(add_or_remove_player, game_id, target) do
+    reply = add_or_remove_player.(game_id, target)
+    {reply, game_id}
+  end
 
-  defp broadcast_on_success(:ok, game_id, socket) do
+  defp broadcast_on_success({:ok, game_id}, socket) do
     :ok = broadcast(socket, "players_updated", %{players: GameServer.players(game_id)})
     :ok = LobbyChannel.notify_game_updated(game_id)
 
     socket
   end
-  defp broadcast_on_success(_, _, socket), do: socket
+  defp broadcast_on_success(_, socket), do: socket
 
 
   defp ok(socket), do: {:reply, :ok, socket}

--- a/lib/ink_flier_web/channels/lobby_channel.ex
+++ b/lib/ink_flier_web/channels/lobby_channel.ex
@@ -8,7 +8,7 @@ defmodule InkFlierWeb.LobbyChannel do
 
   @main_topic "lobby:main"
 
-  def game_updated(game_id), do: Endpoint.broadcast(@main_topic, "game_updated", GameServer.summary_info(game_id))
+  def notify_game_updated(game_id), do: Endpoint.broadcast(@main_topic, "game_updated", GameServer.summary_info(game_id))
 
 
   @impl Phoenix.Channel

--- a/test/ink_flier_web/channels/game_channel_test.exs
+++ b/test/ink_flier_web/channels/game_channel_test.exs
@@ -15,9 +15,7 @@ defmodule InkFlierWeb.GameChannelTest do
   describe "Join game channel" do
     setup [:start_game, :join_game_channel]
 
-    test "If game is deleted while viewing it's page, receive an endpoint broadcast", ~M{game_id} do
-      # NOTE Different from a handle_in or handle_info, Endpoint.broadcast goes straight to js
-      # unless intercepted by channel's handle_out
+    test "Receive an *endpoint* broadcast if game is deleted while viewing it's page", ~M{game_id} do
       :ok = LobbyServer.delete_game(game_id)
       assert_received %{event: "game_deleted"}
     end
@@ -27,7 +25,7 @@ defmodule InkFlierWeb.GameChannelTest do
     setup [:start_game, :join_lobby_channel, :join_game_channel]
 
     test "Broadcast goes to multiple topics (Game AND Lobby)", ~M{game_topic, game_socket} do
-      push(game_socket, "join", %{}) |> assert_reply(:ok)
+      push!(game_socket, "join", %{})
       %{topic: ^game_topic} = assert_broadcast("players_updated", _)
       %{topic: @lobby_topic} = assert_broadcast("game_updated", _)
     end
@@ -41,7 +39,7 @@ defmodule InkFlierWeb.GameChannelTest do
     end
 
     test "Player can remove themselves from game", ~M{game_socket, game_id} do
-      push(game_socket, "leave", %{}) |> assert_reply(:ok)
+      push!(game_socket, "leave", %{})
       assert_broadcast("players_updated", _)
 
       refute game_socket.assigns.user in GameServer.players(game_id)
@@ -50,7 +48,7 @@ defmodule InkFlierWeb.GameChannelTest do
     test "Player can remove *other* target from game", ~M{game_socket, game_id} do
       :ok = GameServer.join(game_id, "Betsy")
 
-      push(game_socket, "leave", %{target: "Betsy"}) |> assert_reply(:ok)
+      push!(game_socket, "leave", %{target: "Betsy"})
       assert_broadcast("players_updated", _)
 
       assert game_socket.assigns.user in GameServer.players(game_id)
@@ -88,7 +86,7 @@ defmodule InkFlierWeb.GameChannelTest do
   end
 
   defp add_self_to_game(~M{game_socket}) do
-    push(game_socket, "join") |> assert_reply(:ok)
+    push!(game_socket, "join")
     assert_broadcast("players_updated", _)
     :ok
   end

--- a/test/ink_flier_web/channels/game_channel_test.exs
+++ b/test/ink_flier_web/channels/game_channel_test.exs
@@ -33,34 +33,26 @@ defmodule InkFlierWeb.GameChannelTest do
     end
   end
 
-  # describe "Join game channel and add self to game" do
-  describe "TODO" do
-    # setup [:start_game, :join_game_channel, :add_self_to_game]
-    setup [:start_game, :join_game_channel]
+  describe "Join game channel and add self to game" do
+    setup [:start_game, :join_game_channel, :add_self_to_game]
 
     test "Player can add themselves to game", ~M{game_socket, game_id} do
-      push(game_socket, "join") |> assert_reply(:ok)
-
-      assert_broadcast("players_updated", _)
       assert game_socket.assigns.user in GameServer.players(game_id)
     end
 
     test "Player can remove themselves from game", ~M{game_socket, game_id} do
-      push(game_socket, "join") |> assert_reply(:ok)
-
       push(game_socket, "leave", %{}) |> assert_reply(:ok)
-
       assert_broadcast("players_updated", _)
+
       refute game_socket.assigns.user in GameServer.players(game_id)
     end
 
     test "Player can remove *other* target from game", ~M{game_socket, game_id} do
-      push(game_socket, "join") |> assert_reply(:ok)
-
       :ok = GameServer.join(game_id, "Betsy")
-      push(game_socket, "leave", %{target: "Betsy"}) |> assert_reply(:ok)
 
+      push(game_socket, "leave", %{target: "Betsy"}) |> assert_reply(:ok)
       assert_broadcast("players_updated", _)
+
       assert game_socket.assigns.user in GameServer.players(game_id)
       refute "Betsy" in GameServer.players(game_id)
     end
@@ -75,7 +67,9 @@ defmodule InkFlierWeb.GameChannelTest do
 
 
   defp test_socket, do: socket(InkFlierWeb.UserSocket, "user_id", %{user: "Robin"})
+
   defp subscribe_test_to_channel(channel, topic), do: subscribe_and_join(test_socket(), channel, topic)
+
 
   defp start_game(_) do
     {:ok, game_id} = LobbyServer.start_game(creator: "BillyBob")
@@ -91,5 +85,11 @@ defmodule InkFlierWeb.GameChannelTest do
   defp join_game_channel(~M{game_topic}) do
     {:ok, _join_reply, game_socket} = subscribe_test_to_channel(InkFlierWeb.GameChannel, game_topic)
     ~M{game_socket}
+  end
+
+  defp add_self_to_game(~M{game_socket}) do
+    push(game_socket, "join") |> assert_reply(:ok)
+    assert_broadcast("players_updated", _)
+    :ok
   end
 end

--- a/test/ink_flier_web/channels/game_channel_test.exs
+++ b/test/ink_flier_web/channels/game_channel_test.exs
@@ -2,6 +2,7 @@ defmodule InkFlierWeb.GameChannelTest do
   use InkFlierWeb.ChannelCase
   import TinyMaps
   alias InkFlier.LobbyServer
+  alias InkFlier.GameServer
 
   @lobby_topic "lobby:main"
 
@@ -30,6 +31,26 @@ defmodule InkFlierWeb.GameChannelTest do
       :ok = LobbyServer.delete_game(game_id)
       assert_received %{event: "game_deleted"}
     end
+  end
+
+  # describe "Join game channel and add self to game" do
+  describe "TODO" do
+    # setup [:start_game, :join_game_channel, :add_self_to_game]
+    setup [:start_game, :join_game_channel]
+
+    test "Player can remove themselves from game", ~M{game_socket, game_id} do
+      push(game_socket, "join") |> assert_reply(:ok)
+      assert game_socket.assigns.user in GameServer.players(game_id)
+      assert_broadcast("players_updated", _)
+    end
+
+    # test "Player can remove other target from game" do
+    #   push(game_socket, "join") |> assert_reply(:ok)
+
+    #   push(game_socket, "leave", %{}) |> assert_reply(:ok)
+    #   refute game_socket.assigns.user in GameServer.players(game_id)
+    #   assert_broadcast("players_updated", _)
+    # end
   end
 
 

--- a/test/ink_flier_web/channels/game_channel_test.exs
+++ b/test/ink_flier_web/channels/game_channel_test.exs
@@ -38,18 +38,21 @@ defmodule InkFlierWeb.GameChannelTest do
     # setup [:start_game, :join_game_channel, :add_self_to_game]
     setup [:start_game, :join_game_channel]
 
-    test "Player can remove themselves from game", ~M{game_socket, game_id} do
+    test "Player can add themselves to game", ~M{game_socket, game_id} do
       push(game_socket, "join") |> assert_reply(:ok)
       assert game_socket.assigns.user in GameServer.players(game_id)
       assert_broadcast("players_updated", _)
     end
 
-    # test "Player can remove other target from game" do
-    #   push(game_socket, "join") |> assert_reply(:ok)
+    test "Player can remove themselves from game", ~M{game_socket, game_id} do
+      push(game_socket, "join") |> assert_reply(:ok)
 
-    #   push(game_socket, "leave", %{}) |> assert_reply(:ok)
-    #   refute game_socket.assigns.user in GameServer.players(game_id)
-    #   assert_broadcast("players_updated", _)
+      push(game_socket, "leave", %{}) |> assert_reply(:ok)
+      refute game_socket.assigns.user in GameServer.players(game_id)
+      assert_broadcast("players_updated", _)
+    end
+
+    # test "Player can remove other target from game", ~M{game_socket, game_id} do
     # end
   end
 

--- a/test/ink_flier_web/channels/game_channel_test.exs
+++ b/test/ink_flier_web/channels/game_channel_test.exs
@@ -12,7 +12,7 @@ defmodule InkFlierWeb.GameChannelTest do
 
 
   describe "Join both lobby and game channels" do
-    setup [:start_game, :join_lobby, :join_game]
+    setup [:start_game, :join_lobby_channel, :join_game_channel]
 
     test "Broadcast goes to multiple topics (Game AND Lobby)", ~M{game_topic, game_socket} do
       push(game_socket, "join", %{}) |> assert_reply(:ok)
@@ -22,7 +22,7 @@ defmodule InkFlierWeb.GameChannelTest do
   end
 
   describe "Start game page" do
-    setup [:start_game, :join_game]
+    setup [:start_game, :join_game_channel]
 
     test "If game is deleted while viewing it's page, receive an endpoint broadcast", ~M{game_id} do
       # NOTE Different from a handle_in or handle_info, Endpoint.broadcast goes straight to js
@@ -43,12 +43,12 @@ defmodule InkFlierWeb.GameChannelTest do
     ~M{game_id, game_topic}
   end
 
-  defp join_lobby(_) do
+  defp join_lobby_channel(_) do
     {:ok, _join_reply, _lobby_socket} = subscribe_test_to_channel(InkFlierWeb.LobbyChannel, @lobby_topic)
     :ok
   end
 
-  defp join_game(~M{game_topic}) do
+  defp join_game_channel(~M{game_topic}) do
     {:ok, _join_reply, game_socket} = subscribe_test_to_channel(InkFlierWeb.GameChannel, game_topic)
     ~M{game_socket}
   end

--- a/test/ink_flier_web/channels/lobby_channel_test.exs
+++ b/test/ink_flier_web/channels/lobby_channel_test.exs
@@ -18,7 +18,7 @@ defmodule InkFlierWeb.LobbyChannelTest do
     end
 
     test "Push delete also works", ~M{socket, game_id} do
-      push(socket, "delete_game", game_id) |> assert_reply(:ok)
+      push!(socket, "delete_game", game_id)
 
       assert LobbyServer.games_info |> length == 0
       assert_broadcast "game_deleted", %{game_id: ^game_id}
@@ -53,8 +53,7 @@ defmodule InkFlierWeb.LobbyChannelTest do
   end
 
   defp push_create_game(~M{socket}) do
-    # push/3 by itself is async. Use assert_reply/4 to wait for reply and not cause a race
-    push(socket, "create_game", %{}) |> assert_reply(:ok)
+    push!(socket, "create_game", %{})
     :ok
   end
 end

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -16,22 +16,23 @@ defmodule InkFlierWeb.ChannelCase do
   """
 
   use ExUnit.CaseTemplate
+  import Phoenix.ChannelTest
 
   using do
     quote do
       # Import conveniences for testing with channels
-      import Phoenix.ChannelTest
       import InkFlierWeb.ChannelCase
+      import Phoenix.ChannelTest
 
       # The default endpoint for testing
       @endpoint InkFlierWeb.Endpoint
-
-      # push/3 by itself is async. Use assert_reply/4 to wait for reply and not cause a race
-      defp push!(socket, msg, payload \\ %{}) do
-        push(socket, msg, payload)
-        |> assert_reply(:ok)
-      end
     end
+  end
+
+  # push/3 by itself is async. Use assert_reply/4 to wait for reply and not cause a race
+  def push!(socket, msg, payload \\ %{}) do
+    push(socket, msg, payload)
+    |> assert_reply(:ok)
   end
 
   setup tags do

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -25,6 +25,12 @@ defmodule InkFlierWeb.ChannelCase do
 
       # The default endpoint for testing
       @endpoint InkFlierWeb.Endpoint
+
+      # push/3 by itself is async. Use assert_reply/4 to wait for reply and not cause a race
+      defp push!(socket, msg, payload \\ %{}) do
+        push(socket, msg, payload)
+        |> assert_reply(:ok)
+      end
     end
   end
 


### PR DESCRIPTION
The "remove player" channel msg always worked when sending no payload/params
  - Since by default, it removed current user

There was a bug where even if you sent a DIFFERENT player name to remove, it would ignore that param and still just remove current user

That is fixed, and correct game channel tests have been added for remove and join